### PR TITLE
👷 Track Debian apt pins with the deb datasource and fix the Tautulli pin

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["/Dockerfile$", "/build.yaml$"],
+      "managerFilePatterns": ["//Dockerfile$/", "//build.yaml$/"],
       "matchStringsStrategy": "any",
       "matchStrings": [
         "ARG BUILD_FROM=(?<depName>.*?):(?<currentValue>.*?)\\s+",
@@ -19,28 +19,31 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["/Dockerfile$"],
+      "managerFilePatterns": ["//Dockerfile$/"],
       "matchStringsStrategy": "any",
       "matchStrings": [
         "\\s\\s(?<package>[a-z0-9][a-z0-9-]+)=(?<currentValue>[a-z0-9-:_+~.]+)\\s+"
       ],
       "versioningTemplate": "deb",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "debian_13/{{package}}"
+      "datasourceTemplate": "deb",
+      "depNameTemplate": "{{{package}}}"
     },
     {
       "customType": "regex",
-      "fileMatch": ["/Dockerfile$"],
-      "matchStrings": [
-        "ENV TAUTULLI_VERSION=[\"']?(?<currentValue>.+?)[\"']?\\s+"
-      ],
+      "managerFilePatterns": ["//Dockerfile$/"],
+      "matchStrings": ["TAUTULLI_VERSION=[\"']?(?<currentValue>.+?)[\"']?\\s+"],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "Tautulli/Tautulli"
     }
   ],
   "packageRules": [
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["deb"],
+      "registryUrls": [
+        "https://deb.debian.org/debian?suite=trixie&components=main&binaryArch=amd64",
+        "https://deb.debian.org/debian?suite=trixie-updates&components=main&binaryArch=amd64",
+        "https://deb.debian.org/debian-security?suite=trixie-security&components=main&binaryArch=amd64"
+      ],
       "automerge": true
     },
     {


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Follows [hassio-addons/app-vaultwarden#447](https://github.com/hassio-addons/app-vaultwarden/pull/447), and fixes a second, unrelated problem in the same file.

**Debian apt pins move to the `deb` datasource**

Repology has become unreliable as a datasource lately: throttling, timeouts, and missing packages. It also forces us to map binary package names onto source package names.

Renovate ships a native [`deb` datasource](https://docs.renovatebot.com/modules/datasource/deb/) that reads the Debian package indices directly, so this switches the apt pins over to it. It indexes **binary** package names, which means `depNameTemplate` becomes plain `{{{package}}}` and the whole name mapping problem disappears.

The registry URLs are a one to one mirror of the apt sources in `ghcr.io/hassio-addons/debian-base:9.4.0`, which builds on `debian:13.6-slim` (trixie):

| Source | Suite | Component |
| --- | --- | --- |
| `deb.debian.org/debian` | `trixie` | `main` |
| `deb.debian.org/debian` | `trixie-updates` | `main` |
| `deb.debian.org/debian-security` | `trixie-security` | `main` |

**Known limitation, with no impact here**

The datasource currently hardcodes `Packages.gz`, but `trixie-updates` and `trixie-security` serve only `Packages.xz`, so those two suites are inert for now. I re-confirmed the 404s. This fails gracefully: lookups are caught and skipped per component, so `trixie` `main` keeps working, and the other two start working by themselves once [renovatebot/renovate#44330](https://github.com/renovatebot/renovate/issues/44330) is resolved. They are kept in the config so it stays a truthful description of what the image actually pulls from.

Unlike vaultwarden, which has `libpq5` pinned from `trixie-security`, this repository is unaffected. I resolved all five pins against the live indices, and every one comes from `trixie` `main` at exactly the version pinned here:

| Package | Pinned | `trixie` `main` | `trixie-updates` | `trixie-security` |
| --- | --- | --- | --- | --- |
| `build-essential` | `12.12` | `12.12` | absent | absent |
| `git` | `1:2.47.3-0+deb13u1` | `1:2.47.3-0+deb13u1` | absent | absent |
| `python3-dev` | `3.13.5-1` | `3.13.5-1` | absent | absent |
| `python3-pip` | `25.1.1+dfsg-1` | `25.1.1+dfsg-1` | absent | absent |
| `python3` | `3.13.5-1` | `3.13.5-1` | absent | absent |

The `git` pin carries a `deb13u1` suffix that reads like a security build, but it has already been folded into `main`.

**The Tautulli version pin has never been tracked**

Separate bug, spotted while in here. The custom manager for the Tautulli release anchored its regex on `ENV TAUTULLI_VERSION=`:

```
"ENV TAUTULLI_VERSION=[\"']?(?<currentValue>.+?)[\"']?\\s+"
```

But the pin lives in a multi-line `ENV` block, where the assignment sits on its own indented continuation line:

```dockerfile
ENV \
  PIP_BREAK_SYSTEM_PACKAGES=1 \
  TAUTULLI_VERSION="v2.16.0"
```

The literal `ENV ` prefix is never adjacent to `TAUTULLI_VERSION=`, so the manager has silently matched nothing and Renovate has never proposed a Tautulli update. Tautulli is pinned at `v2.16.0` from September 2025, while `v2.17.2` has been out since June 2026, so we are three releases behind.

Dropping the `ENV ` anchor fixes it. I deliberately did not convert the pin to an `ARG` on its own line, the way the AdGuard Home app does it, because `TAUTULLI_VERSION` is read at container runtime by `init-tautulli/run` to write the version into `addon.ini`, so it has to stay an `ENV`.

Verified by running each manager's regex over the actual files:

| Manager | Before | After |
| --- | --- | --- |
| base image | `debian-base` `9.4.0` | unchanged |
| apt pins | 5 packages | 5 packages, now via `deb` |
| Tautulli | **no match** | `v2.16.0` |

**Also**

Moves the deprecated `fileMatch` option to `managerFilePatterns`, matching the other app repositories.

**Heads up on what merges next**

Once this lands, Renovate will open a Tautulli `v2.16.0` to `v2.17.2` update. That is a minor bump, and the existing `packageRules` entry automerges minor and patch for `Tautulli/Tautulli`, so it will go straight to main without review. Happy to gate that behind a manual merge for the catch-up jump if you would rather look it over first.

**Validation**

`renovate-config-validator --strict` passes on Renovate 44.41.1, and Prettier is clean.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Ports [hassio-addons/app-vaultwarden#447](https://github.com/hassio-addons/app-vaultwarden/pull/447) to this repository.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
