### PR TITLE
🔥 Drop unused Python dependencies and the build toolchain

### DIFF
--- a/tautulli/Dockerfile
+++ b/tautulli/Dockerfile
@@ -20,16 +20,13 @@ ARG BUILD_ARCH=amd64
 RUN \
   apt-get update \
   && apt-get install -y --no-install-recommends \
-    build-essential=12.12 \
     git=1:2.47.3-0+deb13u1 \
-    python3-dev=3.13.5-1 \
     python3-pip=25.1.1+dfsg-1 \
     python3=3.13.5-1 \
   \
   && pip install \
     --no-cache-dir \
     --prefer-binary \
-    --extra-index-url "https://www.piwheels.org/simple" \
     -r /tmp/requirements.txt \
   \
   && git clone --branch "${TAUTULLI_VERSION}" --depth=1 \
@@ -41,9 +38,7 @@ RUN \
     -exec rm -rf '{}' + \
   \
   && apt-get purge -y --auto-remove \
-    build-essential \
     git \
-    python3-dev \
     python3-pip \
   \
   && rm -fr \

--- a/tautulli/requirements.txt
+++ b/tautulli/requirements.txt
@@ -1,4 +1,1 @@
 crudini==0.9.6
-plexapi==4.18.2
-pycryptodomex==3.23.0
-setuptools==84.0.0


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Of the four packages in `requirements.txt`, only `crudini` is used at runtime. The other three are dead weight, and one of them caused a real outage.

| Package | Why it can go |
| --- | --- |
| `plexapi` | Tautulli vendors it at `lib/plexapi`, and `Tautulli.py` runs `sys.path.insert(0, .../lib)` on line 24 before any other import, so the vendored copy always shadows this one |
| `pycryptodomex` | Never imported. Not a single `Cryptodome` reference anywhere in the Tautulli tree, vendored libraries included, at either v2.16.0 or v2.17.2 |
| `setuptools` | Only needed because the `apscheduler` vendored in Tautulli 2.16 imported `pkg_resources`. Tautulli 2.17 moved to `importlib.metadata` |

I confirmed the `plexapi` shadowing empirically rather than by reading. In an image built from `main`, the pip-installed copy was 4.18.2 while the copy Python actually imported was `/opt/lib/plexapi` at 4.17.0.

**This pin caused a 25 day outage on edge**

Worth recording, because it is the reason this cleanup matters. `pkg_resources` was [removed from setuptools in v82.0.0](https://setuptools.pypa.io/en/latest/history.html). Dependabot merged [#442](https://github.com/hassio-addons/addon-tautulli/pull/442) on 2026-07-30, taking setuptools from 80.10.2 straight to 83.0.0. From that moment the built image could not start:

```
File "/opt/lib/apscheduler/__init__.py", line 1, in <module>
  from pkg_resources import get_distribution, DistributionNotFound
ModuleNotFoundError: No module named 'pkg_resources'
```

I reproduced this by building `main` at `bd88020`: the container exits 1 before the web server ever starts. It was resolved by accident about 90 minutes ago, when [#450](https://github.com/hassio-addons/addon-tautulli/pull/450) bumped Tautulli to v2.17.2 and the newer vendored `apscheduler` stopped needing `pkg_resources`. Current `main` is healthy; I verified that too.

Only edge was affected. The last stable release is v5.0.0 from 2025-11-09, well before the break. The draft v6.0.0 would have shipped it.

Two things are worth noting separately from this PR:

- `#442` was a **major** version bump. Renovate's `packageRules` here only automerge `minor` and `patch`, but Dependabot is also enabled on this repository (there is no `dependabot.yml`, so it comes from repository settings) and is not bound by those rules. Two bots with different policies on the same manifest.
- Removing the package removes this entire class of failure, since nothing here depends on setuptools at all.

**Knock-on cleanup**

With `pycryptodomex` gone there are no C extensions left to compile, so `build-essential` and `python3-dev` are no longer needed, and the piwheels extra index goes with them. That index is worth removing on its own merit: pip merges indexes and picks the highest version across them, so every extra index is a name-shadowing surface. `crudini` is pure Python and needs only `iniparse`.

**Verification**

Built the image and started Tautulli end to end:

```
INFO :: MainThread : Starting Tautulli v2.17.2
INFO :: MainThread : Tautulli WebStart :: Starting Tautulli web server on http://0.0.0.0:8181/
```

`crudini --set` and `--get`, which `init-tautulli/run` depends on, both still work. `gcc`, `cc` and `make` are absent from the final image. Size drops from 187 MB to 179 MB.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Explains the outage introduced by #442 and incidentally resolved by #450.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the application packaging configuration by removing unnecessary build tools and dependency requirements.
  * Simplified Python package installation while retaining required runtime tooling and pinned versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->