### PR TITLE
🐛 Fix operator precedence in the Dockerfile cleanup find

### DIFF
--- a/tautulli/Dockerfile
+++ b/tautulli/Dockerfile
@@ -20,16 +20,13 @@ ARG BUILD_ARCH=amd64
 RUN \
   apt-get update \
   && apt-get install -y --no-install-recommends \
-    build-essential=12.12 \
     git=1:2.47.3-0+deb13u1 \
-    python3-dev=3.13.5-1 \
     python3-pip=25.1.1+dfsg-1 \
     python3=3.13.5-1 \
   \
   && pip install \
     --no-cache-dir \
     --prefer-binary \
-    --extra-index-url "https://www.piwheels.org/simple" \
     -r /tmp/requirements.txt \
   \
   && git clone --branch "${TAUTULLI_VERSION}" --depth=1 \
@@ -41,9 +38,7 @@ RUN \
     -exec rm -rf '{}' + \
   \
   && apt-get purge -y --auto-remove \
-    build-essential \
     git \
-    python3-dev \
     python3-pip \
   \
   && rm -fr \

--- a/tautulli/Dockerfile
+++ b/tautulli/Dockerfile
@@ -32,10 +32,10 @@ RUN \
   && git clone --branch "${TAUTULLI_VERSION}" --depth=1 \
     https://github.com/Tautulli/Tautulli.git /opt \
   \
-  && find /usr/local \
-    \( -type d -a -name test -o -name tests -o -name '__pycache__' \) \
-    -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-    -exec rm -rf '{}' + \
+  && find /usr/local \( \
+      \( -type d -a \( -name test -o -name tests -o -name '__pycache__' \) \) \
+      -o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+    \) -exec rm -rf '{}' + \
   \
   && apt-get purge -y --auto-remove \
     git \

--- a/tautulli/requirements.txt
+++ b/tautulli/requirements.txt
@@ -1,4 +1,1 @@
 crudini==0.9.6
-plexapi==4.18.2
-pycryptodomex==3.23.0
-setuptools==84.0.0


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

> **Stacked on #451.** Based on `drop-unused-python-deps` so the two Dockerfile changes do not conflict. GitHub will retarget this to `main` once #451 merges.

The image cleanup step never did most of its job.

```dockerfile
find /usr/local \
  \( -type d -a -name test -o -name tests -o -name '__pycache__' \) \
  -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
  -exec rm -rf '{}' +
```

`find` binds `-a` tighter than `-o`, and `-exec` is itself an `-a`. So the expression parses as:

```
group1  -o  ( group2  -a  -exec rm -rf {} + )
```

`-exec` attaches only to the branch after the final `-o`. Directories matched by the first group are evaluated, found to match, and then nothing happens to them. Only `*.pyc` and `*.pyo` files were ever deleted.

Demonstrated in a container with the exact expression:

```
BEFORE: pkg/{test, tests/keep.txt, __pycache__/x.txt, a.pyc, b.pyo}
AFTER:  pkg/{test, tests/keep.txt, __pycache__/x.txt}
```

Only the two files went. All three directories survived.

Wrapping both groups in one outer paren before `-exec` makes it apply to the whole expression.

**Verification**

Counting directories under `/usr/local` matching the intended names in a built image:

| Image | Matching directories |
| --- | --- |
| current `main` | 66 |
| with this fix | 0 |

Since the cleanup is now actually effective and deletes more than before, I checked nothing needed was caught: Tautulli still starts and serves on 8181, and `crudini` still works.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Stacked on #451.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
