### PR TITLE
🔥 Remove leftovers from the dropped configuration options

### DIFF
--- a/tautulli/config.yaml
+++ b/tautulli/config.yaml
@@ -4,7 +4,7 @@ version: dev
 slug: tautulli
 description: Monitoring and tracking tool for Plex Media Server
 url: https://github.com/hassio-addons/app-tautulli/tree/main/README.md
-webui: "[PROTO:ssl]://[HOST]:[PORT:8181]"
+webui: "http://[HOST]:[PORT:8181]"
 arch:
   - aarch64
   - amd64

--- a/tautulli/rootfs/etc/s6-overlay/s6-rc.d/init-tautulli/run
+++ b/tautulli/rootfs/etc/s6-overlay/s6-rc.d/init-tautulli/run
@@ -7,9 +7,6 @@
 readonly ADDON=/data/addon.ini
 readonly CONFIG=/data/config.ini
 
-# Check SSL cerrificate
-bashio::config.require.ssl
-
 # If config.ini does not exist, create it.
 if ! bashio::fs.file_exists "$CONFIG"; then
     bashio::log.info "Creating default configuration..."

--- a/tautulli/translations/en.yaml
+++ b/tautulli/translations/en.yaml
@@ -4,33 +4,5 @@ configuration:
     name: Log level
     description: >-
       Controls the level of log details the app provides.
-  username:
-    name: Username
-    description: >-
-      The username for authenticating with the web interface.
-  password:
-    name: Password
-    description: >-
-      The password for authenticating with the web interface.
-  ssl:
-    name: SSL
-    description: >-
-      Enables/Disables SSL (HTTPS) on the web interface.
-  certfile:
-    name: Certificate file
-    description: >-
-      The certificate file to use for SSL. Note that this file must
-      exist in the /ssl/ folder.
-  keyfile:
-    name: Private key file
-    description: >-
-      The private key file to use for SSL. Note that this file must
-      exist in the /ssl/ folder.
-  leave_front_door_open:
-    name: Leave front door open
-    description: >-
-      When enabled, this option disables the username/password authentication
-      on the app. It is STRONGLY suggested not to use this option.
-      USE AT YOUR OWN RISK!
 network:
   8181/tcp: Web interface


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

> **Stacked on #452.** It touches `init-tautulli/run`, which #453 also edits, so the four are kept in a line. GitHub retargets this to `main` as the ones below it merge.

The 2022 rewrite (#214) removed `username`, `password`, `ssl`, `certfile`, `keyfile` and `leave_front_door_open` from the schema, delegating authentication and SSL to Tautulli itself. Three references to those options were left behind and have been dead ever since.

**`webui` still resolved `[PROTO:ssl]`**

```yaml
webui: "[PROTO:ssl]://[HOST]:[PORT:8181]"
```

I checked what Supervisor does with a `[PROTO:...]` naming an option that does not exist, since a `KeyError` there would have been a real bug. It is not: [`apps/app.py`](https://github.com/home-assistant/supervisor/blob/main/supervisor/apps/app.py) reads it with `self.options.get(t_proto)`, so a missing option is falsy and the URL already rendered as `http`.

Nothing was broken, but the template implied a toggle that does not exist. It is now plain `http`.

**`bashio::config.require.ssl` was a guaranteed no-op**

The function opens with:

```bash
if ! bashio::config.true "${key}"; then
    return "${__BASHIO_EXIT_OK}"
fi
```

`bashio::config ssl` returns `null` when the option is not in the schema, `bashio::var.true "null"` is false, so the function returned immediately on every single start.

**The translations described all six options**

The schema has only `log_level`, so those six entries could never surface in the UI. They did give translators six phantom strings to translate, which matters given the translation contributions the sibling repositories receive.

`DOCS.md` needs no change, it already documents `log_level` alone.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Cleans up after #214. Stacked on #452.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
